### PR TITLE
New stepper movement strategy

### DIFF
--- a/Arduino/Esp32/Main/LoadCell.cpp
+++ b/Arduino/Esp32/Main/LoadCell.cpp
@@ -30,7 +30,7 @@ ADS1256& ADC() {
     //adc.sendCommand(ADS1256_CMD_SDATAC);
     
     // start the ADS1256 with data rate of 15kSPS SPS and gain x64
-    adc.begin(ADS1256_DRATE_15000SPS,ADS1256_GAIN_64,false); 
+    adc.begin(ADS1256_DRATE_500SPS,ADS1256_GAIN_64,false); 
     Serial.println("ADC Started");
     
     adc.waitDRDY(); // wait for DRDY to go low before changing multiplexer register

--- a/Arduino/Esp32/Main/LoadCell.cpp
+++ b/Arduino/Esp32/Main/LoadCell.cpp
@@ -10,7 +10,11 @@ static const int NUMBER_OF_SAMPLES_FOR_LOADCELL_OFFFSET_ESTIMATION = 1000;
 static const float DEFAULT_VARIANCE_ESTIMATE = 0.2f * 0.2f;
 static const float LOADCELL_VARIANCE_MIN = 0.001f;
 
-static const float CONVERSION_FACTOR = 4000;      // temporarily hardcoded - this should be adjusted according to load cell rating etc
+static const float LOADCELL_EXCITATION_V = 5;
+static const float LOADCELL_WEIGHT_RATING_KG = 40;
+static const float LOADCELL_SENSITIVITY_MV_V = 2;
+
+static const float CONVERSION_FACTOR = LOADCELL_WEIGHT_RATING_KG / (LOADCELL_EXCITATION_V * (LOADCELL_SENSITIVITY_MV_V/1000));
 
 
 ADS1256& ADC() {

--- a/Arduino/Esp32/Main/Main.ino
+++ b/Arduino/Esp32/Main/Main.ino
@@ -27,6 +27,8 @@ DAP_calculationVariables_st dap_calculationVariables_st;
 
 ForceCurve_Interpolated* forceCurve;
 
+//    define one of these to determine strategy for pedal movement update
+//#define USE_LINEAR_STRATEGY
 #define INTERP_SPRING_STIFFNESS
 
 
@@ -121,6 +123,8 @@ LoadCell_ADS1256* loadcell = NULL;
 #include "StepperWithLimits.h"
 StepperWithLimits* stepper = NULL;
 static const int32_t MIN_STEPS = 5;
+
+#include "StepperMovementStrategy.h"
 
 
 /**********************************************************************************************/
@@ -304,24 +308,13 @@ void loop() {
       
 
       // use interpolation to determine local linearized spring stiffness
-      #ifndef INTERP_SPRING_STIFFNESS
-        float spingStiffnessInv_lcl = dap_calculationVariables_st.springStiffnesssInv;
-        // caclulate pedal position
-        int32_t Position_Next = spingStiffnessInv_lcl * (filteredReading - dap_calculationVariables_st.Force_Min) + dap_calculationVariables_st.stepperPosMin ;        //Calculates new position using linear function
-
-      #else
-        double stepperPosFraction = stepper->getCurrentPositionFraction();
+      #if defined USE_LINEAR_STRATEGY
+        int32_t Position_Next = MoveByLinearStrategy(filteredReading, dap_calculationVariables_st);
         
-        float spingStiffnessInv_lcl = dap_calculationVariables_st.springStiffnesssInv;
-        float springStiffnessInterp = forceCurve->stiffnessAtPosition(stepperPosFraction);
-        if (springStiffnessInterp > 0) {
-          spingStiffnessInv_lcl = (1.0f / springStiffnessInterp);
-        }
+      #elif defined INTERP_SPRING_STIFFNESS
+        double stepperPosFraction = stepper->getCurrentPositionFraction();
+        int32_t Position_Next = MoveByInterpolatedStrategy(filteredReading, stepperPosFraction, forceCurve, dap_calculationVariables_st);
 
-        // caclulate pedal position
-        float pedalForceInterp = forceCurve->forceAtPosition(stepperPosFraction);
-        float stepperPosInterp = forceCurve->stepperPos(stepperPosFraction);
-        int32_t Position_Next = spingStiffnessInv_lcl * (filteredReading - pedalForceInterp) + stepperPosInterp;
 
       #endif
 

--- a/Arduino/Esp32/Main/RTDebugOutput.h
+++ b/Arduino/Esp32/Main/RTDebugOutput.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 
 template <typename TVALUE, int NVALS>
 class RTDebugOutput {

--- a/Arduino/Esp32/Main/StepperMovementStrategy.h
+++ b/Arduino/Esp32/Main/StepperMovementStrategy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "DiyActivePedal_types.h"
+#include "ForceCurve.h"
 
 int32_t MoveByLinearStrategy(float filteredLoadReadingKg, const DAP_calculationVariables_st& calc_st) {
   float spingStiffnessInv_lcl = calc_st.springStiffnesssInv;
@@ -19,4 +20,49 @@ int32_t MoveByInterpolatedStrategy(float filteredLoadReadingKg, float stepperPos
   float pedalForceInterp = forceCurve->forceAtPosition(stepperPosFraction);
   float stepperPosInterp = forceCurve->stepperPos(stepperPosFraction);
   return spingStiffnessInv_lcl * (filteredLoadReadingKg - pedalForceInterp) + stepperPosInterp;
+}
+
+
+int32_t MoveByForceTargetingStrategy(float loadCellReadingKg, StepperWithLimits* stepper, ForceCurve* forceCurve) {
+  float stepperPosFraction = stepper->getCurrentPositionFraction();
+  float loadCellTargetKg = forceCurve->forceAtPosition(stepperPosFraction);
+  float loadCellErrorKg = loadCellReadingKg - loadCellTargetKg;
+
+  // how many mm movement to order if 1kg of error force is detected
+  // this can be tuned for responsiveness vs oscillation
+  static const float MOVE_MM_FOR_1KG = 3.0;
+  static const float MOVE_STEPS_FOR_1KG = (MOVE_MM_FOR_1KG / TRAVEL_PER_ROTATION_IN_MM) * STEPS_PER_MOTOR_REVOLUTION;
+
+  // square the error to smooth minor variations
+  float loadCellErrorMultipler = loadCellErrorKg;
+  if (loadCellErrorKg < 0.0) {
+    loadCellErrorMultipler = sq(max(-1.0f, loadCellErrorKg) / min(1.0f, loadCellTargetKg)) * -1.0;
+  } else if (loadCellErrorKg < 1.0) {
+    loadCellErrorMultipler = sq(loadCellErrorKg);
+  }
+
+  int32_t posStepperChange = loadCellErrorMultipler * MOVE_STEPS_FOR_1KG;
+  int32_t posStepper = stepper->getCurrentPositionSteps();
+  int32_t posStepperNew = posStepper + posStepperChange;
+
+  bool overshoot = false;
+  do {   // check for overshoot
+    float stepperPosFractionNew = stepperPosFraction + (posStepperChange / stepper->getTravelSteps());
+    float loadCellTargetKgAtPosNew = forceCurve->forceAtPosition(stepperPosFractionNew);
+
+    overshoot = 
+      (loadCellTargetKg < loadCellReadingKg && loadCellReadingKg < loadCellTargetKgAtPosNew) ||
+      (loadCellTargetKg > loadCellReadingKg && loadCellReadingKg > loadCellTargetKgAtPosNew);
+
+    if (overshoot) {
+      int32_t corrected = (posStepper + posStepperNew) / 2;
+      if (corrected == posStepperNew) {
+        overshoot = false;
+      } else {
+        posStepperNew = corrected;   // and check again
+      }
+    }
+  } while (overshoot);
+
+  return posStepperNew;
 }

--- a/Arduino/Esp32/Main/StepperMovementStrategy.h
+++ b/Arduino/Esp32/Main/StepperMovementStrategy.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "DiyActivePedal_types.h"
+
+int32_t MoveByLinearStrategy(float filteredLoadReadingKg, const DAP_calculationVariables_st& calc_st) {
+  float spingStiffnessInv_lcl = calc_st.springStiffnesssInv;
+  // caclulate pedal position
+  return spingStiffnessInv_lcl * (filteredLoadReadingKg - calc_st.Force_Min) + calc_st.stepperPosMin ;        //Calculates new position using linear function
+}
+
+int32_t MoveByInterpolatedStrategy(float filteredLoadReadingKg, float stepperPosFraction, const ForceCurve_Interpolated* forceCurve, const DAP_calculationVariables_st& calc_st) {
+  float spingStiffnessInv_lcl = calc_st.springStiffnesssInv;
+  float springStiffnessInterp = forceCurve->stiffnessAtPosition(stepperPosFraction);
+  if (springStiffnessInterp > 0) {
+    spingStiffnessInv_lcl = (1.0f / springStiffnessInterp);
+  }
+
+  // caclulate pedal position
+  float pedalForceInterp = forceCurve->forceAtPosition(stepperPosFraction);
+  float stepperPosInterp = forceCurve->stepperPos(stepperPosFraction);
+  return spingStiffnessInv_lcl * (filteredLoadReadingKg - pedalForceInterp) + stepperPosInterp;
+}

--- a/Arduino/Esp32/Main/StepperWithLimits.cpp
+++ b/Arduino/Esp32/Main/StepperWithLimits.cpp
@@ -101,10 +101,10 @@ int8_t StepperWithLimits::moveTo(int32_t position, bool blocking) {
 }
 
 int32_t StepperWithLimits::getCurrentPositionSteps() const {
-  return _stepper->getCurrentPosition() - _posMin;
+  return _stepper->getCurrentPosition();
 }
 double StepperWithLimits::getCurrentPositionFraction() const {
-  return double(getCurrentPositionSteps()) / getTravelSteps();
+  return double(getCurrentPositionSteps() - _posMin) / getTravelSteps();
 }
 
 int32_t StepperWithLimits::getTargetPositionSteps() const {


### PR DESCRIPTION
This set of changes adds a new "force targeting" movement strategy which requests a target force value for the current pedal position and then attempts to move the pedal so that the measured force will match that value.

This is conceptually somewhat reversed from the existing strategies which measure the current force and calculate a target position based as a function of the force.

The new strategy is disabled by default, but can be swapped in using the new #defines in Main.ino.