### PR TITLE
Task scheduling improvements

### DIFF
--- a/Arduino/Esp32/Main/CycleTimer.h
+++ b/Arduino/Esp32/Main/CycleTimer.h
@@ -1,38 +1,36 @@
 #pragma once
 
 #include "freertos/timers.h"
-
+#include "RTDebugOutput.h"
 
 static const int MAX_CYCLES = 1000;
 
 class CycleTimer {
 private:
-  String _timerName;
-  unsigned long _timeFirst;
+  RTDebugOutput<float, 1> _rtOutput;
+  int64_t _timeFirst;
   unsigned int _cycleCount;
 
 public:
   CycleTimer(String timerName)
-    : _timerName(timerName)
+    : _rtOutput({ timerName })
   {
     ResetTimer();
   }
 
   void ResetTimer() {
-    _timeFirst = esp_timer_get_time();//micros();
+    _timeFirst = esp_timer_get_time();
     _cycleCount = 0;
   }
 
   void Bump() {
     _cycleCount++;
     if (_cycleCount > MAX_CYCLES) {
-
-      ;
-      unsigned long timeEnd = esp_timer_get_time();//micros();
-      unsigned long timeElapsed = timeEnd - _timeFirst;
+      int64_t timeEnd = esp_timer_get_time();
+      int64_t timeElapsed = timeEnd - _timeFirst;
               
-      double averageCycleTime = ((double)timeElapsed) / ((double)MAX_CYCLES); 
-      Serial.print(_timerName); Serial.print(": "); Serial.println(averageCycleTime);
+      float averageCycleTime = float(timeElapsed) / MAX_CYCLES;
+      _rtOutput.offerData({ averageCycleTime });
 
       ResetTimer();
     }

--- a/Arduino/Esp32/Main/Main.ino
+++ b/Arduino/Esp32/Main/Main.ino
@@ -40,9 +40,6 @@ DAP_calculationVariables_st dap_calculationVariables_st;
 #include "CycleTimer.h"
 //#define PRINT_CYCLETIME
 
-static CycleTimer timerPU("PU cycle time");
-static CycleTimer timerSC("SC cycle time");
-
 // target cycle time for pedal update task, to get constant cycle times, required for FIR filtering
 #define PUT_TARGET_CYCLE_TIME_IN_US 100
 
@@ -391,6 +388,7 @@ void pedalUpdateTask( void * pvParameters )
 
     // print the execution time averaged over multiple cycles 
     #ifdef PRINT_CYCLETIME
+      static CycleTimer timerPU("PU cycle time");
       timerPU.Bump();
     #endif
 
@@ -613,6 +611,7 @@ void serialCommunicationTask( void * pvParameters )
 
     // average cycle time averaged over multiple cycles 
     #ifdef PRINT_CYCLETIME
+      static CycleTimer timerSC("SC cycle time");
       timerSC.Bump();
     #endif
 

--- a/Arduino/Esp32/Main/RTDebugOutput.h
+++ b/Arduino/Esp32/Main/RTDebugOutput.h
@@ -67,13 +67,17 @@ public:
   }
 
   void printData() {
-    if(xSemaphoreTake(_semaphore_data, 0) == pdTRUE) {
+    if (xSemaphoreTake(_semaphore_data, 0) == pdTRUE) {
       if (_dataReady) {
-        for (int i=0; i<NVALS; i++) {
-          printValue(_outNames[i], _outValues[i]);
+        static SemaphoreHandle_t semaphore_print = xSemaphoreCreateMutex();
+        if (xSemaphoreTake(semaphore_print, 0) == pdTRUE) {
+          for (int i=0; i<NVALS; i++) {
+            printValue(_outNames[i], _outValues[i]);
+          }
+          Serial.println(" ");
+          xSemaphoreGive(semaphore_print);
+          _dataReady = false;
         }
-        Serial.println(" ");
-        _dataReady = false;
       }
       xSemaphoreGive(_semaphore_data);
     }

--- a/Arduino/Esp32/Main/RTDebugOutput.h
+++ b/Arduino/Esp32/Main/RTDebugOutput.h
@@ -3,83 +3,50 @@
 #include <array>
 
 
-template <typename TVALUE, int NVALS>
+template <typename TVALUE, int NVALS, int FLOAT_PRECISION=6>
 class RTDebugOutput {
 private:
-  SemaphoreHandle_t _semaphore_data;
+  QueueHandle_t _queue_data;
   std::array<String,NVALS> _outNames;
-  std::array<TVALUE,NVALS> _outValues;
-  bool _dataReady;
-  bool _withoutText = false;
   
 public:
-  RTDebugOutput(std::array<String,NVALS> outNames)
+  RTDebugOutput(std::array<String,NVALS> outNames = {})
     : _outNames(outNames)
-    , _dataReady(false)
   {
-    _semaphore_data = xSemaphoreCreateMutex();
+    _queue_data = xQueueCreate(1, sizeof(std::array<TVALUE,NVALS>));
     xTaskCreatePinnedToCore(this->debugOutputTask, "debugOutputTask", 5000, this, 1, NULL, 1);
   }
 
   void offerData(std::array<TVALUE,NVALS> values) {
-    if(xSemaphoreTake(_semaphore_data, 0) == pdTRUE) {
-      _outValues = values;
-      _dataReady = true;
-      _withoutText = false;
-      xSemaphoreGive(_semaphore_data);
-    }
+    xQueueSend(_queue_data, &values, /*xTicksToWait=*/0);
   }
-
-
-  void offerDataWithoutText(std::array<TVALUE,NVALS> values) {
-    if(xSemaphoreTake(_semaphore_data, 0) == pdTRUE) {
-      _outValues = values;
-      _dataReady = true;
-      _withoutText = true;
-      xSemaphoreGive(_semaphore_data);
-    }
-  }
-
   
 
   template <typename T>
   void printValue(String name, T value) {
-
-    if (_withoutText == false)
-    {
-      Serial.print(name); Serial.print(":"); Serial.print(value); Serial.print(",");
+    if (name.length() > 0) {
+      Serial.print(name); Serial.print(":"); 
     }
-    else
-    {
-      Serial.print(value, 9); Serial.print(",");
-    }
-    
+    Serial.print(value); Serial.print(",");
   }
   void printValue(String name, float value) {
-    if (_withoutText == false)
-    {
-      Serial.print(name); Serial.print(":"); Serial.print(value,6); Serial.print(",");
+    if (name.length() > 0) {
+      Serial.print(name); Serial.print(":"); 
     }
-    else
-    {
-      Serial.print(value, 9); Serial.print(",");
-    }
+    Serial.print(value, FLOAT_PRECISION); Serial.print(",");
   }
 
   void printData() {
-    if (xSemaphoreTake(_semaphore_data, 0) == pdTRUE) {
-      if (_dataReady) {
+    std::array<TVALUE,NVALS> values;
+    if (pdTRUE == xQueueReceive(_queue_data, &values, /*xTicksToWait=*/0)) {
         static SemaphoreHandle_t semaphore_print = xSemaphoreCreateMutex();
-        if (xSemaphoreTake(semaphore_print, 0) == pdTRUE) {
+        if (xSemaphoreTake(semaphore_print, /*xTicksToWait=*/10) == pdTRUE) {
           for (int i=0; i<NVALS; i++) {
-            printValue(_outNames[i], _outValues[i]);
+            printValue(_outNames[i], values[i]);
           }
           Serial.println(" ");
           xSemaphoreGive(semaphore_print);
-          _dataReady = false;
         }
-      }
-      xSemaphoreGive(_semaphore_data);
     }
   }
 

--- a/Arduino/Esp32/Main/StepperMovementStrategy.h
+++ b/Arduino/Esp32/Main/StepperMovementStrategy.h
@@ -261,12 +261,11 @@ void measureStepResponse(StepperWithLimits* stepper, const DAP_calculationVariab
       currentPos = stepper->getCurrentPositionFraction();
       loadcellReading = (loadcellReading - calc_st->Force_Min) / calc_st->Force_Range; 
 
-      static RTDebugOutput<float, 3> rtDebugFilter({ "t", "y", "F"});
-      rtDebugFilter.offerDataWithoutText({ ((float)t) *1e-6 , currentPos,  loadcellReading});   
+      static RTDebugOutput<float, 3, 9> rtDebugFilter;
+      rtDebugFilter.offerData({ ((float)t) *1e-6 , currentPos,  loadcellReading});   
     }
   }
 
   Serial.println("======================================");
   Serial.println("End system identification data");
 }
-


### PR DESCRIPTION
On a single-core chip, task switching between the pedal update task and the serial task was only happening on a full scheduler tick - once per ms. This meant that the pedal update task would cycle a few times without the serial output being updated, and then the serial task would cycle for a full ms without having any fresh pedal updates to process after the first loop.

Using a single-item queue, and telling the serial task to wait for the queue, means that each pedal update triggers the serial task directly, so that they swap out the processing time much more efficiently.